### PR TITLE
[FIX] `Header` Title Wrapping

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,7 +22,7 @@ export const HeaderNav: React.FC<HeaderNavProps> = ({ title, showBack }) => {
           />
         )}
       </div>
-      <p className="absolute left-1/2 -translate-x-1/2 text-xl font-bold">
+      <p className="absolute left-1/2 max-w-[75%] -translate-x-1/2 truncate text-xl font-bold whitespace-nowrap">
         {title}
       </p>
       <div className="h-6 w-6"></div>


### PR DESCRIPTION
…ader overflowing

### Please tell us what you did
1. Added `max-width: 75%` and `truncate` to stop overflowing
2. Added `whitespace-nowrap`
3.
4.

### Are there any concerns that may be raised ?



### Please add which issue does this PR close below using ("closes #issue_number")
Closes #22 